### PR TITLE
Make fly team aware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-MAINTAINER Malte Schirmacher <malte.schirmacher@etecture.de>
+MAINTAINER Troy Kinsella <troy.kinsella@gmail.com>
 
 COPY assets/* /opt/resource/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-MAINTAINER Troy Kinsella <troy.kinsella@gmail.com>
+MAINTAINER Malte Schirmacher <malte.schirmacher@etecture.de>
 
 COPY assets/* /opt/resource/
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently only HTTP basic authentication is supported.
 * `url`: _Required_. The base URL of the concourse instance to contact. (i.e. https://example.com/concourse)
 * `username`: _Required_. The concourse basic auth username.
 * `password`: _Required_. The concourse basic auth password.
+* `team`: _Optional_. The concourse team to work upon. Defaults to `main`
 
 ### Example
 
@@ -32,6 +33,7 @@ resources:
     url: {{concourse_url}}
     username: {{concourse_username}}
     password: {{concourse_password}}
+    team: your-team
 ```
 
 ## Behaviour
@@ -54,7 +56,7 @@ Concourse instance if not already present or if there is a version mismatch betw
 
 Parameters are passed through to the `fly` command as follows:
 ```sh
-fly -t main $command $options
+fly -t $team $command $options
 ```
 `main` is the name of the target Concourse instance.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ resources:
     url: {{concourse_url}}
     username: {{concourse_username}}
     password: {{concourse_password}}
-    team: your-team
+    team: {{concourse_team}}
 ```
 
 ## Behaviour

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -15,16 +15,17 @@ login() {
   local url="$1"
   local username="$2"
   local password="$3"
-  local tried="$4"
+  local team="$4"
+  local tried="$5"
 
   set +e
-  local out=$($FLY login -t main -c "$url" --username="$username" --password="$password" 2>&1)
+  local out=$($FLY login -t main -n "$team"-c "$url" --username="$username" --password="$password" 2>&1)
 
   # This sucks
   echo "$out" | grep "fly -t main sync" > /dev/null && {
     test -n "$tried" && return 1;
     fetch_fly;
-    login "$url" "$username" "$password" yes;
+    login "$url" "$username" "$password" "$team" yes;
   }
   set -e
 }
@@ -33,7 +34,8 @@ init_fly() {
   local url="$1"
   local username="$2"
   local password="$3"
+  local team="$4"
 
   fetch_fly "$url"
-  login "$url" "$username" "$password"
+  login "$url" "$username" "$password" "$team"
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -19,7 +19,7 @@ login() {
   local tried="$5"
 
   set +e
-  local out=$($FLY login -t main -n "$team"-c "$url" --username="$username" --password="$password" 2>&1)
+  local out=$($FLY login -t main -n "$team" -c "$url" --username="$username" --password="$password" 2>&1)
 
   # This sucks
   echo "$out" | grep "fly -t main sync" > /dev/null && {

--- a/assets/out
+++ b/assets/out
@@ -11,6 +11,7 @@ payload=$(mktemp $TMPDIR/fly-resource-request.XXXXXX)
 cat > $payload <&0
 
 url=$(jq -r '.source.url // ""' < $payload)
+test -z "$url" && url=$ATC_EXTERNAL_URL
 test -z "$url" && { echo "Must supply 'url' source attribute"; exit 1; }
 
 team=$(jq -r '.source.team // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -13,6 +13,9 @@ cat > $payload <&0
 url=$(jq -r '.source.url // ""' < $payload)
 test -z "$url" && { echo "Must supply 'url' source attribute"; exit 1; }
 
+team=$(jq -r '.source.team // ""' < $payload)
+test -z "$team" && team=main
+
 username=$(jq -r '.source.username // ""' < $payload)
 test -z "$username" && { echo "Must supply 'username' source attribute"; exit 1; }
 
@@ -26,7 +29,7 @@ options=$(jq -r '.params.options // ""' < $payload)
 
 init_fly "$url" "$username" "$password"
 
-fly -t main "$command" $options
+fly -t main -n "$team" "$command" $options
 
 jq -n "{
   version: {}

--- a/assets/out
+++ b/assets/out
@@ -28,9 +28,9 @@ test -z "$command" && { echo "Must supply 'command' parameter"; exit 1; }
 
 options=$(jq -r '.params.options // ""' < $payload)
 
-init_fly "$url" "$username" "$password"
+init_fly "$url" "$username" "$password" "$team"
 
-fly -t main -n "$team" "$command" $options
+fly -t main "$command" $options
 
 jq -n "{
   version: {}


### PR DESCRIPTION
The resource badly lacked support for teams - this PR changes it.
The resource configuration now get support for a `team` key which will be used throughout the calls. 
The config value defaults to `main` so this PR shouldn't break existing pipelines