### PR TITLE
Add version output for in

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -1,2 +1,5 @@
 #!/bin/sh
-echo "{}"
+
+jq -n "{
+  version: {}
+}"


### PR DESCRIPTION
For a new version of concourse we're getting errors related to there being no version output in all in scripts.  Can we add this output to the in script to combat this?