### PR TITLE
Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,5 @@ RUN apk add --no-cache \
     bash \
     ca-certificates \
     curl \
-    jq \
-    openssh \
-    openssl \
-    && update-ca-certificates
+    jq ;\
+    update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:edge
-MAINTAINER Troy Kinsella <troy.kinsella@gmail.com>
+LABEL MAINTAINER="Troy Kinsella <troy.kinsella@gmail.com>"
 
 COPY assets/* /opt/resource/
 
@@ -10,4 +10,4 @@ RUN apk add --no-cache \
     jq \
     openssh \
     openssl \
- && update-ca-certificates
+    && update-ca-certificates

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Currently only HTTP basic authentication is supported.
 * `team`: _Optional_. The concourse team to login to. Default: "main".
 * `insecure`: _Optional_. Set to `true` to skip TLS verification.
 * `debug`: _Optional_. Set to `true` to print commands for troubleshooting, including credentials.
+* `secure_output`: _Optional_. Set to `true` to suppress output from `fly`.
+* `multiline_lines`: _Optional_. Set to `true` to interpret `\` as one line (mostly for big options line).
 
 ### Example
 

--- a/assets/out
+++ b/assets/out
@@ -23,6 +23,8 @@ test -z "$password" && { echo "Must supply 'password' source attribute"; exit 1;
 team=$(jq -r '.source.team // "main"' < $payload)
 insecure=$(jq -r '.source.insecure // "false"' < $payload)
 debug=$(jq -r '.source.debug // "false"' < $payload)
+multiline_lines=$(jq -r '.source.multiline_lines // "false"' < $payload)
+secure_output=$(jq -r '.source.secure_output // "true"' < $payload)
 
 options=$(jq -r '.params.options // ""' < $payload)
 options_file=$(jq -r '.params.options_file // ""' < $payload)
@@ -44,9 +46,17 @@ test "$debug" = "true" && set -x
 
 init_fly $url $username $password $team $insecure
 
-while read -r line; do
+READSWITCH="-r"
+
+if [ "$multiline_lines" = true ]; then
+  READSWITCH=""
+fi
+
+while read $READSWITCH line; do
   (
-    set -x
+    if [ "$secure_output" = false ]; then
+      set -x
+    fi
     fly -t main $line
   )
 done <<< "$options"

--- a/assets/out
+++ b/assets/out
@@ -40,7 +40,12 @@ if [ -z "$options" ]; then
   echo "Must supply some options to fly"
   exit 1
 fi
-echo "Options: $options"
+
+if [ "$secure_output" = false ]; then
+  echo "Options: $options"
+else
+  echo "Options: ##SUPRESSED##"
+fi
 
 test "$debug" = "true" && set -x
 


### PR DESCRIPTION
- MAINTAINER option is deprecated in Dockerfile
- `secure_output` option to avoid echoing credentials when setting teams.
- `multiline_lines` to give the ability to not escape `\` and have clearer pipelines
```
set-team -n TEAM \
  --generic-oauth-oidc-display-name SSO \
  --generic-oauth-oidc-client-id client-id \
  --generic-oauth-oidc-client-secret client-secret \
  --generic-oauth-oidc-groups group \
  --generic-oauth-oidc-auth-url https://google.com/auth/fasdfasdf/asdfasdfasdf/asdfasdfadfs/asdfasfdafd/auth \
  --generic-oauth-oidc-token-url https://google.com/auth/fasdfasdf/asdfasdfasdf/asdfasdfadfs/asdfasfdafd/token \
  --generic-oauth-oidc-scope openid \
  --non-interactive
```

instead of `set-team -n TEAM --generic-oauth-oidc-display-name SSO --generic-oauth-oidc-client-id client-id --generic-oauth-oidc-client-secret client-secret --generic-oauth-oidc-groups group --generic-oauth-oidc-auth-url https://google.com/auth/fasdfasdf/asdfasdfasdf/asdfasdfadfs/asdfasfdafd/auth --generic-oauth-oidc-token-url https://google.com/auth/fasdfasdf/asdfasdfasdf/asdfasdfadfs/asdfasfdafd/token --generic-oauth-oidc-scope openid --non-interactive`